### PR TITLE
Basic files for building the project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+Makefile.coq
+Makefile.coq.conf
+_build
+*~
+*.d
+*.aux
+*.glob
+*.vo
+*.vio
+*.vok
+*.vos
+.lia.cache
+.nia.cache
+.nra.cache

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+all: Makefile.coq
+	@+$(MAKE) -f Makefile.coq all
+
+clean: Makefile.coq
+	@+$(MAKE) -f Makefile.coq cleanall
+	@rm -f Makefile.coq Makefile.coq.conf
+
+Makefile.coq: _CoqProject
+	$(COQBIN)coq_makefile -f _CoqProject -o Makefile.coq
+
+force _CoqProject Makefile: ;
+
+%: Makefile.coq force
+	@+$(MAKE) -f Makefile.coq $@
+
+.PHONY: all clean force

--- a/_CoqProject
+++ b/_CoqProject
@@ -1,0 +1,9 @@
+-Q . Actuary
+
+all_Actuary.v
+Basics.v
+Examples.v
+Interest.v
+LifeTable.v
+Premium.v
+Reserve.v


### PR DESCRIPTION
In its current state, this project is difficult for people to build with Coq. In this pull request, I introduce basic standard build scripts and metadata. 

This means that most Coq users, if they have MathComp and Coquelicot installed, can simply run this command to build the project:
```
make
``` 
If someone wants to install the project and and depend on it in their code, it suffices to then run:
```
make install
```

Having an easy build is not only good for people who download the code using GitHub. It is also useful when [packaging](https://coq.inria.fr/opam-packaging.html) releases of the project in Coq's [opam repository](https://github.com/coq/opam-coq-archive).