### PR TITLE
Compatibility with Coq 8.14 and MathComp 1.13

### DIFF
--- a/LifeTable.v
+++ b/LifeTable.v
@@ -755,12 +755,11 @@ Proof.
   apply False_ind.
   set (K := (fun u:R => \l_u = 0)).
   have HpsiCK : (complementary K) \ψ by [].
-  have HKclosed : closed_set K.
+  have : closed_set K.
   { rewrite (_ : K = image_rec l (eq^~ 0)) //.
     apply continuity_closed; [apply eq_R_continuous; auto |].
     apply Rsingleton_closed. }
-  rewrite /closed_set in HKclosed.
-  apply open_set_P1 in HKclosed.
+  apply/open_set_P1 => HKclosed.
   have HpsiNBH : neighbourhood (complementary K) \ψ
     by rewrite -/(interior _ \ψ); apply HKclosed.
   rewrite /neighbourhood in HpsiNBH.

--- a/_CoqProject
+++ b/_CoqProject
@@ -1,5 +1,8 @@
 -Q . Actuary
 
+-arg -w -arg -notation-overridden
+-arg -w -arg -ambiguous-paths
+
 all_Actuary.v
 Basics.v
 Examples.v


### PR DESCRIPTION
Here are minimal changes so that the repository builds with Coq 8.14 and the [recently released](https://coq.discourse.group/t/mathcomp-1-13-0-released/1474) MathComp 1.13.0 (and Coquelicot 3.2.0). I've also tested that 8.13 with MathComp 1.12.0 and Coquelicot 3.1.0 works fine after the change. To only see relevant warnings during builds, I suppress the unavoidable warnings in `_CoqProject`.