### PR TITLE
Fix nat deprecations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ _build
 .lia.cache
 .nia.cache
 .nra.cache
+.coq-native/

--- a/theories/Basics.v
+++ b/theories/Basics.v
@@ -13,7 +13,7 @@ Qed.
 
 Lemma iota_rcons : forall (m n : nat), rcons (iota m n) (m+n) = iota m (n+1).
 Proof.
- by move => m n; rewrite -(cats0 (rcons _ _)) cat_rcons iota_add.
+ by move => m n; rewrite -(cats0 (rcons _ _)) cat_rcons iotaD.
 Qed.
 
 Lemma iota_pttn : forall (n m : nat),
@@ -21,7 +21,7 @@ Lemma iota_pttn : forall (n m : nat),
 Proof.
  move => n; elim n => [// | p IHp].
  move => m.
- rewrite mulSn addnC iota_add add0n.
+ rewrite mulSn addnC iotaD add0n.
  rewrite -IHp.
  rewrite -flatten_rcons -(map_id (iota (p*m) m)) -map_rcons.
  by rewrite iota_rcons addn1.

--- a/theories/Interest.v
+++ b/theories/Interest.v
@@ -602,7 +602,7 @@ Proof.
     rewrite -(Rinv_r_simpl_l m j) /Rdiv; [| apply /pos_neq0 /Hmpos];
     apply Rmult_lt_compat_r; [apply Rinv_0_lt_compat => // | ].
     rewrite -(plus_INR _ 1) -mult_INR;
-    apply lt_INR; rewrite Nat.add_1_r; apply le_lt_n_Sm; case: (andP Hk) => /leP //.
+    apply lt_INR; rewrite Nat.add_1_r; apply Nat.lt_succ_r; case: (andP Hk) => /leP //.
    rewrite -(Rinv_r_simpl_l m (_ + _)%Z) /Rdiv; [| apply /pos_neq0 /Hmpos];
    apply Rmult_le_compat_r; [by apply /Rlt_le /Rinv_0_lt_compat |].
    rewrite plus_IZR -INR_IZR_INZ -!S_INR -mult_INR; apply le_INR; rewrite -/(lt k _).

--- a/theories/LifeTable.v
+++ b/theories/LifeTable.v
@@ -293,9 +293,9 @@ Hint Resolve psi_finite : core.
 Lemma omega_pos : 0 < \ω.
 Proof.
   rewrite -Nat2Z.inj_0; apply Rlt_gt; rewrite -INR_IZR_INZ; apply lt_INR.
-  apply neq_0_lt => Homega0.
+  apply Nat.neq_0_lt_0 => Homega0.
   apply (Rlt_irrefl \l_\ω).
-  rewrite {1}l_omega_0  -Homega0.
+  rewrite {1}l_omega_0  Homega0.
   apply l_0_pos.
 Qed.
 
@@ -447,7 +447,7 @@ Proof.
     rewrite 2!big_split /=.
     rewrite -(Rplus_0_r (\Rsum_(0 <= i < \ω-x) i * \p_{i&x})).
     rewrite -{2}(Rmult_0_r (\ω-x)) -{2}(p_omega_0 x).
-    rewrite -(minus_INR \ω x); [| apply /Nat.lt_le_incl /lt_O_minus_lt; rewrite /lt //].
+    rewrite -(minus_INR \ω x); [| apply /Nat.lt_le_incl /(Nat.lt_add_lt_sub_r 0); rewrite /lt //].
     rewrite -(big_nat_recr (\ω-x) 0) /= ; [| rewrite /leP //].
     rewrite big_nat_recl //.
     rewrite Rmult_0_l Rplus_0_l.
@@ -475,7 +475,7 @@ Proof.
       - rewrite S_INR.
         over.
       - rewrite -(plus_INR x 1).
-        apply /pos_neq0 /l_x_pos /lt_INR /lt_O_minus_lt.
+        apply /pos_neq0 /l_x_pos /lt_INR /(Nat.lt_add_lt_sub_r 0).
         rewrite Nat.sub_add_distr.
         apply lt_minus_O_lt.
         move /ltP in Halive1.
@@ -483,15 +483,15 @@ Proof.
     rewrite -big_distrr.
     rewrite -{1}(Rmult_1_r (\p_x)).
     rewrite -Rmult_plus_distr_l.
-      by rewrite pred_of_minus -SSR_minus -subnDA e_p plus_INR.
-  - apply lt_n_Sm_le in Hdead.
+      by rewrite -Nat.sub_1_r -SSR_minus -subnDA e_p plus_INR.
+  - apply (Nat.lt_succ_r (\ω - x)) in Hdead.
     apply Nat.le_1_r in Hdead.
     destruct Hdead as [H0 | H1].
     + rewrite H0.
       rewrite big_geq //.
       rewrite (p_old_0 x 1); [rewrite Rmult_0_l // |].
       apply Nat.sub_0_le in H0.
-      rewrite -plus_INR; apply /le_INR /(le_trans _ x) => //; lia.
+      rewrite -plus_INR; apply /le_INR /(Nat.le_trans _ x) => //; lia.
     + rewrite H1.
       rewrite big_nat1 Rplus_0_l.
       rewrite e_p subnDA H1 SSR_minus Nat.sub_diag.

--- a/theories/Premium.v
+++ b/theories/Premium.v
@@ -514,7 +514,7 @@ Proof.
       rewrite -Ropp_mult_distr_l -/(Rdiv _ m) -/(Rminus _ (k/m)).
       over.
     - rewrite add0n.
-      apply /lt_le_S /ltP.
+      apply /Nat.le_succ_l /ltP.
       move: Hk => /andP; intuition. }
     by [].
 Qed.
@@ -553,7 +553,7 @@ Proof.
       rewrite Rdiv_plus_distr (Rmult_comm m n) /Rdiv Rinv_r_simpl_l; auto.
       rewrite /= -Ropp_mult_distr_l -/(Rdiv _ m) -/(Rminus _ (_ / _)).
       over.
-    - apply /lt_le_S /ltP.
+    - apply /Nat.le_succ_l /ltP.
       move: Hk => /andP; intuition. }
     by [].
 Qed.
@@ -571,7 +571,7 @@ Proof.
   have Hn' : (0 < n)%coq_nat by (apply INR_lt => //).
   have Hm' : (0 < m)%coq_nat by (apply INR_lt => //).
   rewrite /life_ann_due.
-  rewrite (S_pred (m*n) 0); [| rewrite /muln /muln_rec; lia].
+  rewrite -(Nat.lt_succ_pred 0 (m*n)); [| rewrite /muln /muln_rec; lia].
   rewrite big_nat_recl; [| apply /leP; lia].
   rewrite {1 2}/Rdiv Rmult_0_l.
   rewrite Rpower_O; [| apply /v_pos /i_pos]; rewrite p_0_1 // Rmult_1_r.
@@ -663,10 +663,10 @@ Lemma ann_due_1_imm : forall (x n : nat), x < \ω -> 0 < n -> \a''_{x:n} = 1 + \
 Proof.
   move => x n Hx Hn.
   rewrite ann_annual ann_due_annual.
-  rewrite {1}(S_pred n 0); [| apply INR_lt => //].
+  rewrite -{1}(Nat.lt_succ_pred 0 n); [| apply INR_lt => //].
   rewrite big_nat_recl //.
   rewrite Rpower_O; [| apply /v_pos /i_pos]; rewrite p_0_1 // Rmult_1_r.
-  rewrite pred_of_minus -SSR_minus.
+  rewrite -Nat.sub_1_r -SSR_minus.
     by under eq_big_nat => k Hk do rewrite S_INR.
 Qed.
 
@@ -683,14 +683,14 @@ Proof.
     rewrite Rpower_O; [| apply /v_pos /i_pos]; rewrite p_0_1; lra.
   - have Hmn : (0 < m * n)%coq_nat
       by apply /ltP; rewrite muln_gt0; apply /andP; split; apply /ltP.
-    rewrite {2}(S_pred (m*n) 0) //.
+    rewrite -{2}(Nat.lt_succ_pred 0 (m*n)) //.
     rewrite big_nat_recl; [| apply /leP; lia].
     rewrite /(Rdiv 0) Rmult_0_l.
     rewrite Rpower_O; [| apply /v_pos /i_pos]; rewrite p_0_1 // Rmult_1_r.
     rewrite (Rplus_comm 1) Ropp_r_simpl_l.
-    rewrite [in LHS](S_pred (m*n) 0) //.
+    rewrite -[in LHS](Nat.lt_succ_pred 0 (m*n)) //.
     rewrite (_ : \v^n * \p_{n&x} = (\v^(((m*n).-1.+1)/m) * \p_{((m*n).-1.+1)/m&x}));
-      [|rewrite -(S_pred _ 0) // mulnC mult_INR /Rdiv Rinv_r_simpl_l; auto].
+      [|rewrite (Nat.lt_succ_pred 0) // mulnC mult_INR /Rdiv Rinv_r_simpl_l; auto].
     rewrite -(big_nat_recr _ _ _ ); [| apply /leP; lia].
       by under eq_big_nat => k Hk do [rewrite (_ : 1 = 1%N) // -plus_INR Nat.add_1_r].
 Qed.
@@ -807,7 +807,7 @@ Proof.
         !Rmult_opp1_l -Rplus_assoc (Rplus_assoc x n) Rplus_opp_r Rplus_0_r Ropp_involutive.
       rewrite -Nat.add_1_r plus_INR /= -/(Rdiv _ m).
       over.
-    - apply /lt_le_S /ltP.
+    - apply /Nat.le_succ_l /ltP.
       move: Hk => /andP; intuition. }
     by [].
 Qed.
@@ -964,7 +964,7 @@ Proof.
   move => x n Hxn Hn.
   rewrite acc_annual acc_due_annual.
   rewrite {1}(_ : n = (n-1).+1);
-    [| rewrite SSR_minus -pred_of_minus -(S_pred _ 0) //;
+    [| rewrite SSR_minus Nat.sub_1_r (Nat.lt_succ_pred 0) //;
          apply INR_lt; rewrite (_ : INR 0%N = 0) //].
   rewrite big_nat_recl; [| apply /leP; move: Hn => /(INR_lt 0); lia].
   rewrite Rpower_O ?Rmult_1_l; auto.
@@ -985,7 +985,7 @@ Proof.
   have Hn' : (0 < n)%coq_nat by apply INR_lt.
   rewrite acc_due_annual.
   rewrite {1}(_ : n = (n-1).+1);
-    [| rewrite SSR_minus -pred_of_minus -(S_pred _ 0) //;
+    [| rewrite SSR_minus Nat.sub_1_r (Nat.lt_succ_pred 0) //;
          apply INR_lt; rewrite (_ : INR 0%N = 0) //].
   rewrite big_nat_recr /=; [| apply /leP; lia].
   rewrite (_ : (n-1)%N+1 = n); [| rewrite minus_INR /=; [lra | lia]].

--- a/theories/Reserve.v
+++ b/theories/Reserve.v
@@ -298,8 +298,8 @@ Proof.
   rewrite res_endow_prem_ann_due //.
   rewrite (_ : \P^{m}_{x:n} + \d^{m} = /(\a''^{m}_{x:n})); [lra |].
   rewrite prem_endow_ann_due_d //; [lra |].
-  apply lt_INR; move: Hx' => /INR_lt; apply le_lt_trans.
-  rewrite -{1}(addn0 x); apply plus_le_compat_l; lia.
+  apply lt_INR; move: Hx' => /INR_lt; apply Nat.le_lt_trans.
+  rewrite -{1}(addn0 x); apply Nat.add_le_mono_l; lia.
 Qed.
   
 Lemma res_endow_ins_endow : forall m t x n : nat, 0 < m -> x+t < \ω -> 0 < n ->
@@ -308,8 +308,8 @@ Proof.
   move => m t x n Hm Hxt Hn.
   have Hxt' : (x+t)%N < \ω by rewrite plus_INR //.
   have Hx : x < \ω.
-  { apply lt_INR; move: Hxt' => /INR_lt; apply le_lt_trans.
-    rewrite -{1}(addn0 x); apply plus_le_compat_l; lia. }
+  { apply lt_INR; move: Hxt' => /INR_lt; apply Nat.le_lt_trans.
+    rewrite -{1}(addn0 x); apply Nat.add_le_mono_l; lia. }
   have Hd : \d^{m} <> 0 by apply /pos_neq0 /d_nom_pos => //=; lra.
   have Ha'' : \a''^{m}_{x:n} <> 0
     by  apply pos_neq0; eapply Rlt_le_trans;
@@ -330,8 +330,8 @@ Proof.
   move => m t x n Hm Htn Hxt Hn.
   have Hxt' : (x+t)%N < \ω by rewrite plus_INR //.
   have Hx : x < \ω.
-  { apply lt_INR; move: Hxt' => /INR_lt; apply le_lt_trans.
-    rewrite -{1}(addn0 x); apply plus_le_compat_l; lia. }
+  { apply lt_INR; move: Hxt' => /INR_lt; apply Nat.le_lt_trans.
+    rewrite -{1}(addn0 x); apply Nat.add_le_mono_l; lia. }
   have Htn' :  0 < (n - t)%N
     by rewrite SSR_minus minus_INR; [lra | apply INR_le; lra].
   have Ha'' : \a''^{m}_{ (x + t) : n - t} <> 0


### PR DESCRIPTION
Some lemmas related to `nat` are getting deprecated in recent Coq and MathComp. Here I solve these deprecations in a backwards-compatible way.

@Yosuke-Ito-345 if you merge this, please consider doing a GitHub release/tag, e.g., `v2.1.1`. I can put this release on opam, which should ensure the opam package is compatible with Coq 8.13 to 8.16, i.e., it will stay relevant for quite a long time.